### PR TITLE
fix incorrect yunohost function calls

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -103,7 +103,7 @@ ynh_add_nginx_config
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
-ynh_replace_string "__NODEJS__" "$nodejs_use_version" "/etc/systemd/system/$app.service"
+ynh_replace_string "__NODEJS__" "$nodejs_version" "/etc/systemd/system/$app.service"
 ynh_replace_string "__ENV_PATH__" "$PATH" "/etc/systemd/system/$app.service"
 ynh_replace_string "__NODE__" "$nodejs_path" "/etc/systemd/system/$app.service"
 systemctl daemon-reload

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -89,7 +89,7 @@ ynh_add_nginx_config
 ynh_replace_string "__NODE__" "$nodejs_path" "../conf/systemd.service"
 ynh_replace_string "__NODEJS__" "$nodejs_version" "../conf/systemd.service"
 ynh_replace_string "__ENV_PATH__" "$PATH" "../conf/systemd.service"
-ynh_systemd_config
+ynh_add_systemd_config
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -80,7 +80,7 @@ sudo chmod 755 $final_path -R
 # Modify Nginx configuration file and copy it to Nginx conf directory
 #=================================================
 
-ynh_nginx_config
+ynh_add_nginx_config
 
 #=================================================
 # ADD SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -39,7 +39,7 @@ port=$(ynh_app_setting_get "$app" port)
 if [ -f "/etc/yunohost/apps/$app/scripts/backup" ] ; then
   ynh_backup_before_upgrade # Backup the current version of the app
   ynh_clean_setup () {
-      ynh_backup_after_failed_upgrade
+      ynh_restore_upgradebackup
   }
   ynh_abort_if_errors	# Stop script if an error is detected
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -87,7 +87,7 @@ ynh_add_nginx_config
 #=================================================
 
 ynh_replace_string "__NODE__" "$nodejs_path" "../conf/systemd.service"
-ynh_replace_string "__NODEJS__" "$nodejs_use_version" "../conf/systemd.service"
+ynh_replace_string "__NODEJS__" "$nodejs_version" "../conf/systemd.service"
 ynh_replace_string "__ENV_PATH__" "$PATH" "../conf/systemd.service"
 ynh_systemd_config
 


### PR DESCRIPTION
after fixing #31 with #32 and then attempting another upgrade just now, I hit another block. While the previous error was on [line 50 of the upgrade script](https://github.com/YunoHost-Apps/cryptpad_ynh/blob/2da2f16a74ede27d65ea9cbaf1f3624135865a6f/scripts/upgrade#L50), the error has now moved forward to [line 83](https://github.com/YunoHost-Apps/cryptpad_ynh/blob/e1088215f54256c12b9332d54b236d2466a1efcc/scripts/upgrade#L83).

Stacktrace :
```
Info: Now upgrading app cryptpad…
Info: Installation of N - Node.js version management
Warning: ./upgrade: line 83: ynh_nginx_config: command not found
Warning: [ERR] !!
Warning:   cryptpad's script has encountered an error. Its execution was cancelled.
Warning: !!
Warning: Please find here an extract of the log before the crash:
Warning: [DEBUG]: DEBUG   -
Warning: [DEBUG]: DEBUG   - + tar -xf app.tar.gz -C /var/www/cryptpad --strip-components 1
Warning: [DEBUG]: DEBUG   - ++ find /var/cache/yunohost/from_file/cryptpad_ynh-e1088215f54256c12b9332d54b236d2466a1efcc/scripts/../sources/patches/ -type f -name 'app-*.patch'
Warning: [DEBUG]: DEBUG   - ++ wc -l
Warning: [DEBUG]: DEBUG   - + ((  0 > 0  ))
Warning: [DEBUG]: DEBUG   - + test -e /var/cache/yunohost/from_file/cryptpad_ynh-e1088215f54256c12b9332d54b236d2466a1efcc/scripts/../sources/extra_files/app
Warning: [DEBUG]: DEBUG   - + sudo chown cryptpad: /var/www/cryptpad -R
Warning: [DEBUG]: DEBUG   - + sudo chmod 755 /var/www/cryptpad -R
Warning: [DEBUG]: DEBUG   - + ynh_nginx_config
Warning: [DEBUG]: WARNING - ./upgrade: line 83: ynh_nginx_config: command not found
Warning: [DEBUG]: DEBUG   - + ynh_exit_properly
Warning: ./upgrade: line 42: ynh_backup_after_failed_upgrade: command not found
Warning: 
Error: Unable to upgrade cryptpad
Info: The operation 'Upgrade 'cryptpad' application' has failed! To get help, please share the full log of this operation using the command 'yunohost log display 20191002-132922-app_upgrade-cryptpad --share'
Error: The following apps were not upgraded: cryptpad
```
I thought there could be other places with such issues like #31. So, then I went around looking for other issues that might have cropped in from the past ( like deprecation that went unnoticed, etc ). I caught some that would likely break an upgrade.

PS : The upgrade version listed on my admin panel says 2.16.0 whereas the [shipped version is 3.2.0](https://github.com/YunoHost-Apps/cryptpad_ynh/blob/e1088215f54256c12b9332d54b236d2466a1efcc/README.md#L7). Was the version upgrade missed to be notified to yunohost or isn't 3.2.0 not yet released on yunohost?
![Screenshot_2019-10-02 YunoHost admin](https://user-images.githubusercontent.com/4771718/66051008-d1ff7b00-e54b-11e9-8d05-e6e4e9ad664a.png)