### PR TITLE
Fix install upgrade inconsistencies

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -151,17 +151,6 @@ bower install --allow-root
 popd
 
 #=================================================
-# INSTALL CRYPTPAD
-#=================================================
-
-script_dir="$PWD"
-pushd "$final_path"
-npm install --allow-root
-npm install -g bower --allow-root
-bower install --allow-root
-popd
-
-#=================================================
 # Set some permissions
 #=================================================
 

--- a/scripts/install
+++ b/scripts/install
@@ -131,7 +131,7 @@ ynh_replace_string "__PORT__" "$port" "$final_path/config/config.js"
 ynh_replace_string "__PORTI__" "$porti" "$final_path/config/config.js"
 
 # Tune CSP to allow for YunoHost tile
-#ynh_replace_string "\"script-src 'self'\"" "\"script-src 'self' 'unsafe-eval'\"" "$final_path/config.js"
+#ynh_replace_string "\"script-src 'self'\"" "\"script-src 'self' 'unsafe-eval'\"" "$final_path/config/config.js"
 # Remove donate button
 ynh_replace_string "removeDonateButton: false" "removeDonateButton: true" "$final_path/config/config.js"
 # Disable analytics unsolicited communications

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,16 +112,17 @@ popd
 ynh_backup_if_checksum_is_different "$final_path/config.js"
 
 # Copy default configuration file
-sudo mv "$final_path/config.example.js" "$final_path/config.js"
+mv "../conf/config.js" "$final_path/config.js"
 
 # Set service port
-ynh_replace_string "httpPort: 3000" "httpPort: $port" "$final_path/config.js"
+ynh_replace_string "__PORT__" "$port" "$final_path/config/config.js"
+ynh_replace_string "__PORTI__" "$porti" "$final_path/config/config.js"
 # Tune CSP to allow for YunoHost tile
 ynh_replace_string "\"script-src 'self'\"" "\"script-src 'self' 'unsafe-eval'\"" "$final_path/config.js"
 # Remove donate button
 ynh_replace_string "removeDonateButton: false" "removeDonateButton: true" "$final_path/config.js"
 # Disable analytics unsolicited communications
-ynh_replace_string "adminEmail: 'i.did.not.read.my.config@cryptpad.fr'" "adminEmail: false" "$final_path/config.js"
+ynh_replace_string "__ADMIN_EMAIL_" "$admin_email" "$final_path/config.js"
 
 # Store file checksum to detected user modifications on upgrade
 ynh_store_file_checksum "$final_path/config.js"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,19 +91,6 @@ ynh_replace_string "__NODEJS__" "$nodejs_version" "../conf/systemd.service"
 ynh_replace_string "__ENV_PATH__" "$PATH" "../conf/systemd.service"
 ynh_add_systemd_config
 
-
-#=================================================
-# INSTALL CRYPTPAD
-#=================================================
-
-script_dir="$PWD"
-pushd "$final_path"
-chown -R $app: $final_path
-npm install
-npm install -g bower
-exec_login_as $app cd $final_path && env PATH=$PATH bower install
-popd
-
 #=================================================
 # CONFIGURE SERVER.JS	
 #=================================================
@@ -126,6 +113,18 @@ ynh_replace_string "__ADMIN_EMAIL_" "$admin_email" "$final_path/config.js"
 
 # Store file checksum to detected user modifications on upgrade
 ynh_store_file_checksum "$final_path/config.js"
+
+#=================================================
+# INSTALL CRYPTPAD
+#=================================================
+
+script_dir="$PWD"
+pushd "$final_path"
+chown -R $app: $final_path
+npm install
+npm install -g bower
+exec_login_as $app cd $final_path && env PATH=$PATH bower install
+popd
 
 #=================================================
 # SET FILES OWNERSHIP

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -97,22 +97,23 @@ ynh_add_systemd_config
 
 # Backup configuration file if changed
 ynh_backup_if_checksum_is_different "$final_path/config.js"
+ynh_backup_if_checksum_is_different "$final_path/config/config.js"
 
 # Copy default configuration file
-mv "../conf/config.js" "$final_path/config.js"
+mv "../conf/config.js" "$final_path/config/config.js"
 
 # Set service port
 ynh_replace_string "__PORT__" "$port" "$final_path/config/config.js"
 ynh_replace_string "__PORTI__" "$porti" "$final_path/config/config.js"
 # Tune CSP to allow for YunoHost tile
-ynh_replace_string "\"script-src 'self'\"" "\"script-src 'self' 'unsafe-eval'\"" "$final_path/config.js"
+ynh_replace_string "\"script-src 'self'\"" "\"script-src 'self' 'unsafe-eval'\"" "$final_path/config/config.js"
 # Remove donate button
-ynh_replace_string "removeDonateButton: false" "removeDonateButton: true" "$final_path/config.js"
+ynh_replace_string "removeDonateButton: false" "removeDonateButton: true" "$final_path/config/config.js"
 # Disable analytics unsolicited communications
-ynh_replace_string "__ADMIN_EMAIL_" "$admin_email" "$final_path/config.js"
+ynh_replace_string "__ADMIN_EMAIL_" "$admin_email" "$final_path/config/config.js"
 
 # Store file checksum to detected user modifications on upgrade
-ynh_store_file_checksum "$final_path/config.js"
+ynh_store_file_checksum "$final_path/config/config.js"
 
 #=================================================
 # INSTALL CRYPTPAD


### PR DESCRIPTION
I found some inconsistencies with the install and upgrade scripts and thought I should fix those. I'm not 100% sure whether they are supposed to be that way but I took a stab at them anyway.

Also, it looks like the path for the configuration files has been in 2 places, viz, `$final_path/config.js` and `$final_path/config/config.js`. Since the cryptpad [installation guide](https://github.com/xwiki-labs/cryptpad/wiki/Installation-guide#configuration) mentions to use `$final_path/config`, I modified all the configuration files to be at `$final_path/config/config.js`.