### PR TITLE
Fix linter issues

### DIFF
--- a/check_process
+++ b/check_process
@@ -7,7 +7,7 @@
 		is_public="1"	(PUBLIC|public=1|private=0)
 	; Checks
 		pkg_linter=1
-		setup_sub_dir=0
+		setup_sub_dir=1
 		setup_root=1
 		setup_nourl=0
 		setup_private=1

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -176,6 +176,14 @@ ynh_script_progression --message="Upgrading systemd configuration..." --weight=1
 chown -R $app:$app $final_path
 
 #=================================================
+# INTEGRATE SERVICE IN ADMIN PANEL
+#=================================================
+ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
+
+# Ajoute le service au monitoring de Yunohost.
+yunohost service add $app --log "/var/log/$app/$app.log"
+
+#=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1


### PR DESCRIPTION
- Fix linter issues:
  `setup_sub_dir` set to 0 instead of 1
  Missing `yunohost service add` in upgrade script

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/cryptpad_ynh%20PR54%20(ericgaspar)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/cryptpad_ynh%20PR54%20(ericgaspar)/)  