### PR TITLE
Update install wording

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -177,7 +177,8 @@ message="CryptPad was successfully installed :)
 
 Please open your $app domain: https://$domain$path_url
 
-Once CryptPad is installed, create an account via the Register button on the home page. To make this account an instance administrator:
+Once CryptPad is installed, create an account via the Sign Up button on the home page which will take you to the Register page. 
+To make this account an instance administrator:
 
 1. Copy the public key found in User Menu (avatar at the top right) > Settings > Account > Public Signing Key
 2. Paste this key in /var/www/cryptpad/config/config.js in the following array (uncomment and replace the placeholder):


### PR DESCRIPTION
Change wording in email sent to admin so they don't look for the word 'register' which is not there.

## Problem

-  when email came i went looking for a button or link called 'register' on the home page but it wasn't there.  After hitting 'sign up' it came to the Register page.  This PR will make instructions a bit more clear.

## Solution

- change wording

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
