### PR TITLE
Testing

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -175,7 +175,7 @@ yunohost service add $app --description="Zero Knowledge realtime collaborative e
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="server available"
+ynh_systemd_action --service_name=$app --action="start" --log_path="systemd"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -208,11 +208,6 @@ if ! [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
 fi
 
 #=================================================
-# RELOAD YUNOHOST-API to refresh web admin domains after domain creation (normal?)
-#=================================================
-#ynh_systemd_action --service_name=yunohost-api --action=reload
-
-#=================================================
 # RELOAD NGINX
 #=================================================
 ynh_script_progression --message="Reloading NGINX web server..." --weight=1

--- a/scripts/install
+++ b/scripts/install
@@ -210,7 +210,7 @@ fi
 #=================================================
 # RELOAD YUNOHOST-API to refresh web admin domains after domain creation (normal?)
 #=================================================
-ynh_systemd_action --service_name=yunohost-api --action=reload
+#ynh_systemd_action --service_name=yunohost-api --action=reload
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

- no need to restart yunohost-api after sandbox domain creation
- no need to catch a line from systemd start since the service needs admin tuning to be fully operational

## Solution

- code adapted to solve issue

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
