### PR TITLE
don't keep customize folder

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -90,7 +90,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path" --keep="config/config.js customize/"
+	ynh_setup_source --dest_dir="$final_path" --keep="config/config.js"
 	
 	chmod 750 "$final_path"
 	chmod -R o-rwx "$final_path"


### PR DESCRIPTION
The files are different in this release, it is better not keep old files...

## Problem

- The files are different in this release, to proceed customizing, the method is paste files from customize.dist folder in customize folder

## Solution

- don't keep this folder, we need do again the method process.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
