### PR TITLE
Remove full_domain option in manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -33,7 +33,6 @@ ram.runtime = "50M"
     help.en = "CryptPad needs to be installed in a dedicated domain or sub-domain."
     help.fr = "CryptPad doit être installé dans un domaine ou sous-domaine dédié."
     type = "domain"
-    full_domain = true
 
     [install.init_main_permission]
     help.en = "If 'Visitors' enabled, CryptPad will be accessible by people who do not have an account. This can be changed later via the webadmin."


### PR DESCRIPTION
## Problem
Error when trying to install cryptpad on Armbian Bookworm : 
```
ERROR While parsing manifest: 1 validation error for OptionsModel
options -> 0 -> DomainOption -> full_domain
  extra fields not permitted (type=value_error.extra)
Command 'yunohost app install cryptpad --force --args 'admin=groot&password=obfuscated&domain=crypt.clic.merlinsystem.com&language=fr&is_public=yes' &>> ./data/install_cryptpad.logs' returned non-zero exit status 1.
```

## Solution
Remove full_domain option in manifest.toml

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
