### PR TITLE
Add cert_alternate_names hook for sandbox domain

### DIFF
--- a/hooks/cert_alternate_names
+++ b/hooks/cert_alternate_names
@@ -1,0 +1,13 @@
+# This script is expected to be called xx-$app
+app=$(basename $0 | cut -d- -f2)
+app_domain=$(yunohost app setting $app domain)
+sandboxdomain=$(yunohost app setting $app sandboxdomain)
+
+if [[ "$domain" != "$app_domain" ]]
+then
+    exit 0
+fi
+
+cat << EOF >> $YNH_STDRETURN
+- $sandboxdomain
+EOF


### PR DESCRIPTION
Implementing @Josue-T's suggestion in #217, I discovered some assumption in the hook's code that made it impossible to add a SAN if it is not in the domain's tree, cf. https://github.com/YunoHost/yunohost/pull/1994
That patch needs to be applied to test this PR on Cryptpad.

FYI @mathilde-cryptpad @Ddataa 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
