### PR TITLE
fix sandboxing ports

### DIFF
--- a/conf/nginx-sandbox.conf
+++ b/conf/nginx-sandbox.conf
@@ -51,7 +51,7 @@ server {
     error_log /var/log/nginx/__DOMAIN__-error.log;
 
     location / {
-        proxy_pass            http://localhost:3000;
+        proxy_pass            http://localhost:__PORT__;
         proxy_set_header      X-Real-IP $remote_addr;
         proxy_set_header      Host $host;
         proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -63,7 +63,7 @@ server {
     }
 
     location ^~ /cryptpad_websocket {
-        proxy_pass            http://localhost:3003;
+        proxy_pass            http://localhost:__PORT_SOCKET__;
         proxy_set_header      X-Real-IP $remote_addr;
         proxy_set_header      Host $host;
         proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "CryptPad"
 description.en = "Zero Knowledge realtime collaborative office suite"
 description.fr = "Suite bureautique chiffrée pour la collaboration en temps réel"
 
-version = "2024.12.0~ynh4"
+version = "2024.12.0~ynh5"
 
 maintainers = ["ddataa"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -22,7 +22,7 @@ fund = "https://opencollective.com/cryptpad/contribute?language=fr"
 yunohost = ">= 12.0.9"
 helpers_version = "2.1"
 architectures = "all"
-multi_instance = false
+multi_instance = true
 
 ldap = false
 sso = false


### PR DESCRIPTION
## Problem

- *Description of why you made this PR*
https://forum.yunohost.org/t/cryptpad-sandbox-has-the-same-internal-port-as-wanderer-trails-app/35190

## Solution

- *And how do you fix that problem*
Make the ports 3000 and 3003 as variables

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
